### PR TITLE
Add control over tone length precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ var tone = require('tonegenerator')
 var tonedata = tone({
   freq: 440,
   lengthInSecs: 2.0,
+  lengthPrecision: 'round',
   volume: 30,
   rate: 44100,
   shape: 'triangle'
@@ -25,6 +26,7 @@ var tonedata = tone(frequency, lengthInSeconds, volume = 30, rate = 44100)
 #### Using the new interface
 - **freq** frequency in hertz. *defaults to 440*
 - **lengthInSecs** controls the length of the array output together with the samplerate *defaults to 2.0*
+- **lengthPrecision** controls how tones should try to match lengthInSecs. Options are *'clipexact', 'padexact', 'round'* The first two will produce consistent lengths for all frequencies and shapes. *defaults to 'round'*
 - **volume** controls max/min for the array values. If you intend to write 8-bit it should be less than or equal to tone.MAX_8, if 16 bit it should be less than or equal to tone.MAX_16. *defaults to 30*
 - **rate** sample rate, number of samples per second. Together with lengthInSecs, this define the length of the output array (lengthInSeccs * rate). *defaults to 44100*
 - **shape** controls the wave shape. Options are *'triangle', 'square', 'sine', 'saw'*. You can also pass in a custom function, see the tests for an example of this. *defaults to 'sine'*
@@ -39,7 +41,7 @@ The old interface takes four arguments: *freq, lengthInSecs, volume, rate*.
 tone.MAX_8 // max volume to be used with 8-bit sound
 tone.MAX_16 // max volume for 16 bit sound
 
-```javascript
+​```javascript
 var tone = require('tonegenerator');
 var A440 = tone({ freq: 440, lengthInSeconds: 20, volume: 30 }); // get PCM data for a 440hz A, 20 seconds, volume 30
 var A440_low_sample = tone(440, 20, 30, 22050); // (old interface) this array has lower sample rate and will only be half as long

--- a/index.js
+++ b/index.js
@@ -60,17 +60,35 @@ function generateWaveForm(opts) {
   var rate = opts.rate || 44100
   var lengthInSecs = opts.lengthInSecs || 2.0;
   var volume = opts.volume || 30;
+  var lengthPrecision = opts.lengthPrecision || 'round';
   var shape = opts.shape || 'sine';
 
   var cycle = Math.floor(rate/freq);
-  var samplesLeft = lengthInSecs * rate;
+  var samplesLeft = Math.floor(lengthInSecs * rate);
   var cycles = samplesLeft/cycle;
+
+  switch (lengthPrecision) {
+    case 'clipexact':
+      cycles = Math.ceil(cycles);
+    case 'padexact':
+      cycles = Math.floor(cycles);
+    default:
+      cycles = Math.round(cycles);
+  }
+
   var ret = [];
 
   for(var i = 0; i < cycles; i++) {
     ret = ret.concat(generateCycle(cycle, volume, shape));
   }
 
+  switch (lengthPrecision) {
+    case 'padexact':
+      ret = ret.concat(new Array(samplesLeft - ret.length).fill(0));
+    case 'clipexact':
+      ret.splice(samplesLeft);
+  }
+  
   return ret;
 };
 

--- a/index.js
+++ b/index.js
@@ -51,6 +51,9 @@ function generateCycle(cycle, volume, shape) {
     tmp = generator(i, cycle, volume);
     data[i] = Math.round(tmp);
   }
+
+  if (volume === 0) { data.fill(0); }
+
   return data;
 }
 
@@ -59,8 +62,8 @@ function generateWaveForm(opts) {
   var freq = opts.freq || 440;
   var rate = opts.rate || 44100
   var lengthInSecs = opts.lengthInSecs || 2.0;
-  var volume = opts.volume || 30;
   var lengthPrecision = opts.lengthPrecision || 'round';
+  var volume = typeof opts.volume == 'number' ? opts.volume : 30;
   var shape = opts.shape || 'sine';
 
   var cycle = Math.floor(rate/freq);


### PR DESCRIPTION
The current `tonegenerator` is inconsistent with duration; if you attempt to create 3 tones of different frequencies but the same duration, the 3 tones will have slightly different sample counts. This is undesirable when generating tones for any scenario that requires precise durations.

This PR mostly preserves the current default behavior (rounds the number of cycles to the nearest match) but introduces 2 precise modes:
- `lengthPrecision: 'padextact'`
  - When needed, this will generate 1 cycle less than the target duration, but pad the remaining time with silence to precisely/consistently meet the requested duration.
- `lengthPrecision: 'clipexact'`
  - This will always create tones with a precise/consistent length, but tones may be clipped in the middle of their last cycle.  That can produce audio pops in some cases, but ensures that the audible tone duration is exactly as specified.